### PR TITLE
fix removing account

### DIFF
--- a/src/features/settings/settingsManager.ts
+++ b/src/features/settings/settingsManager.ts
@@ -12,6 +12,7 @@ import { signOut } from 'firebase/auth';
 import { useRouter } from 'next/router';
 import { useApplicationContext } from 'features/application/context';
 import { auth, db } from 'firebaseConfiguration';
+import { FirebaseError } from 'firebase/app';
 
 export const useSettingsManager = () => {
   const { loading, error, user } = useApplicationContext();
@@ -28,8 +29,6 @@ export const useSettingsManager = () => {
   }
 
   const handleOnAccountDelete = async () => {
-    // TO DO: this is not working properly to run user.delete(); we need to force to reauthenticate again.
-    // when the user is logged in for more than 5 minutes, an error will be returned
     try {
       if (!user) {
         return;
@@ -58,7 +57,11 @@ export const useSettingsManager = () => {
       toast.success('Account deleted');
       signOut(auth);
     } catch (error) {
-      toast.error('Error deleting account');
+      if (error instanceof FirebaseError && error.code === 'auth/requires-recent-login') {
+        toast.error('For security reasons, please sign in again to delete your account');
+        signOut(auth);
+        await router.replace('/login');
+      }
     }
     setIsRemoving(false);
   };

--- a/src/features/settings/settingsManager.ts
+++ b/src/features/settings/settingsManager.ts
@@ -53,14 +53,21 @@ export const useSettingsManager = () => {
       await deleteDoc(doc(db, 'users', user.uid));
 
       closeDeleteModal();
-      await router.replace('/login');
       toast.success('Account deleted');
       signOut(auth);
     } catch (error) {
-      if (error instanceof FirebaseError && error.code === 'auth/requires-recent-login') {
-        toast.error('For security reasons, please sign in again to delete your account');
+      if (
+        error instanceof FirebaseError &&
+        error.code === 'auth/requires-recent-login'
+      ) {
+        toast.error(
+          'For security reasons, please sign in and delete your account again'
+        );
         signOut(auth);
-        await router.replace('/login');
+        await router.replace({
+          pathname: '/login',
+          query: { redirect: '/settings' },
+        });
       }
     }
     setIsRemoving(false);

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,7 +1,7 @@
 import { Form, Formik } from 'formik';
 import Head from 'next/head';
 import Link from 'next/link';
-import router from 'next/router';
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { signInWithGoogle, signInWithGithub } from 'firebaseConfiguration';
 import withAnimation from 'shared/HOC/withAnimation';
@@ -16,11 +16,18 @@ import Google from '../../../public/images/google.svg';
 function LoginPage() {
   const { loading, user } = useApplicationContext();
   const { initialValues, LoginSchema, onSubmit } = useLoginManager();
+  const router = useRouter();
+  const { redirect } = router.query;
 
   useEffect(() => {
     if (user) {
-      router.push('/');
+      if (redirect === 'settings') {
+        router.push('/settings');
+      } else {
+        router.push('/');
+      }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user, loading]);
 
   return (

--- a/src/shared/HOC/withProtectedRoute.tsx
+++ b/src/shared/HOC/withProtectedRoute.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import { ComponentType } from 'react';
-import { useCallback, useEffect } from 'react';
 import { useApplicationContext } from 'features/application/context';
 
 const withProtectedRoute = (WrappedComponent: ComponentType) => {
@@ -9,17 +8,10 @@ const withProtectedRoute = (WrappedComponent: ComponentType) => {
     const isLoggedIn = user && !error;
     const location = useRouter();
 
-    const redirectToHome = useCallback(() => {
-      location.replace('/login');
-    }, [location]);
+    if (!loading && !isLoggedIn && location.pathname !== '/login') {
+      location.push('/login');
+    }
 
-    useEffect(() => {
-      if (!isLoggedIn && !loading) {
-        redirectToHome();
-      }
-    }, [isLoggedIn, loading, redirectToHome]);
-
-    if (loading) return null;
     if (isLoggedIn) {
       return <WrappedComponent {...props} />;
     }


### PR DESCRIPTION
Fixes #123

> If you go to settingsManager file in handleOnAccountDelete you will notice that  user.delete() will not working when user is logged to account since long time. To fix this we need reauthorize user after confirming the deletion of the account. We need display correct authorization method in the modal and after that remove account.